### PR TITLE
fix: handle pages not being listed in config.js

### DIFF
--- a/pyflip.py
+++ b/pyflip.py
@@ -127,22 +127,22 @@ class Pyflip:
 
         base_url = "https://online.anyflip.com"
 
-        if not page_file_names:
-            for i in range(1, page_count + 1):
-                download_path = anyflip_url + "files/mobile/" + f"{i}.jpg"
-                download_url = base_url + download_path
-                new_flipbook.page_urls.append(download_url)
-        else:
-            for i in range(page_count):
+        for i in range(page_count):
+            # Check that config.js has this page
+            if i < len(page_file_names):
                 download_path = anyflip_url + "files/large/" + page_file_names[i]
-                download_url = base_url + download_path
-                new_flipbook.page_urls.append(download_url)
+            # Else fallback on numbers
+            else:
+                download_path = anyflip_url + "files/large/" + f"{i + 1}.jpg"
+            
+            download_url = base_url + download_path
+            new_flipbook.page_urls.append(download_url)
 
         return new_flipbook
 
     @staticmethod
     def download_images(download_folder: str, flipbook: Flipbook) -> None:
-        """Downloads the PDF as a series of images"""
+        """Downloads the PDF as a series of images, skipping missing pages."""
         try:
             # Make the folder
             os.makedirs(download_folder, exist_ok=True)


### PR DESCRIPTION
Some books only had some of their page urls listed in the `config.js`.
This meant that when trying to iterate through all the pages in the book (e.g. 400) and only some page urls were listed (e.g. 4) a index out of range error would be thrown.

This is fixed by checking if the current page count is within the listed page urls (by checking the length of the list of page urls) and using the fallback generic url if it isn't.

Further optimisation is possible by only checking once per book instead of checking every page, but this currently works.

Fixes #2.